### PR TITLE
Fix transformer forward input shape

### DIFF
--- a/neural_network.py
+++ b/neural_network.py
@@ -31,11 +31,8 @@ class TransformerEncoderNetwork(nn.Module):
         return predicted_classes
 
     def forward(self, x):
-
         x = self.embedding(x)
-        x = x.unsqueeze(1)
         x = self.transformer_encoder(x)
-        x = x.squeeze(1)
         output = self.output_layer(x)
         return output
 


### PR DESCRIPTION
## Summary
- keep transformer encoder input 3-D

## Testing
- `python -m pytest -q` *(fails: no module named pytest)*
- `python -m unittest discover`